### PR TITLE
Add inventory.yml for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 collections/
 inventory
+inventory.yml

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,14 @@
 if [ -t "0" ]; then
   ANSIBLE_FORCE_COLORS=True
 fi
-INVENTORY_FILE="$(dirname $0)/inventory"
+
+if [ -f "$(dirname $0)/inventory.yml" ]; then
+  INVENTORY_FILE="$(dirname $0)/inventory.yml"
+else
+  INVENTORY_FILE="$(dirname $0)/inventory"
+fi
+
+echo "Using Inventory File: ${INVENTORY_FILE}"
 
 check_ansible() {
   type -p ansible-playbook > /dev/null


### PR DESCRIPTION
This adds an inventory.yml file so we can leave the default version alone.
Also display the inventory file used.
We should probably also add an -i option to set an inventory file.