### PR TITLE
Add info playbooks to diplay login info at end

### DIFF
--- a/playbooks/info_ascender.yml
+++ b/playbooks/info_ascender.yml
@@ -1,0 +1,30 @@
+- hosts: ascender
+  gather_facts: yes
+  become: true
+  environment:
+    K8S_AUTH_KUBECONFIG: "{{ K8S_AUTH_KUBECONFIG }}"
+    NAMESPACE: "{{ ASCENDER_NAMESPACE }}"
+
+  tasks:
+    - name: Get the Admin password
+      kubernetes.core.k8s_info:
+        api: v1
+        kind: Secret
+        name: ascender-admin-password
+        namespace: "{{ ASCENDER_NAMESPACE }}"
+      register: ascender_password
+
+    - name: Get the Service Port
+      kubernetes.core.k8s_info:
+        api: v1
+        kind: Service
+        name: ascender-service
+        namespace: "{{ ASCENDER_NAMESPACE }}"
+      register: ascender_service
+
+    - name: Display results
+      ansible.builtin.debug:
+        msg:
+          - "ASCENDER USERNAME: admin"
+          - "ASCENDER PASSWORD: {{ ascender_password.resources[0].data.password | b64decode }}"
+          - "ASCENDER URL: http://{{ hostvars[groups['ascender'][0]].ansible_host }}:{{ ascender_service.resources[0].spec.ports[0].nodePort }}/"

--- a/playbooks/info_ledger.yml
+++ b/playbooks/info_ledger.yml
@@ -1,0 +1,29 @@
+- hosts: ledger
+  become: true
+  environment:
+    K8S_AUTH_KUBECONFIG: "{{ K8S_AUTH_KUBECONFIG }}"
+    NAMESPACE: "{{ LEDGER_NAMESPACE }}"
+
+  tasks:
+    - name: Get the Admin password
+      kubernetes.core.k8s_info:
+        api: v1
+        kind: Secret
+        name: admin-password
+        namespace: "{{ LEDGER_NAMESPACE }}"
+      register: ledger_password
+
+    - name: Get the Service Port
+      kubernetes.core.k8s_info:
+        api: v1
+        kind: Service
+        name: web-svc
+        namespace: "{{ LEDGER_NAMESPACE }}"
+      register: ledger_service
+
+    - name: Display results
+      ansible.builtin.debug:
+        msg:
+          - "LEDGER USERNAME: admin"
+          - "LEDGER PASSWORD: {{ ledger_password.resources[0].data['admin-password'] | b64decode }}"
+          - "LEDGER URL: http://{{ hostvars[groups['ledger'][0]].ansible_host }}:{{ ledger_service.resources[0].spec.ports[0].nodePort }}/"

--- a/playbooks/install_ascender.yml
+++ b/playbooks/install_ascender.yml
@@ -10,26 +10,5 @@
     - k8s
     - ascender_install
 
-  tasks:
-    - name: Get the Admin password
-      kubernetes.core.k8s_info:
-        api: v1
-        kind: Secret
-        name: ascender-admin-password
-        namespace: "{{ ASCENDER_NAMESPACE }}"
-      register: ascender_password
-
-    - name: Get the Service Port
-      kubernetes.core.k8s_info:
-        api: v1
-        kind: Service
-        name: ascender-service
-        namespace: "{{ ASCENDER_NAMESPACE }}"
-      register: ascender_service
-
-    - name: Display results
-      ansible.builtin.debug:
-        msg:
-          - "ASCENDER USERNAME: admin"
-          - "ASCENDER PASSWORD: {{ ascender_password.resources[0].data.password | b64decode }}"
-          - "ASCENDER URL: http://{{ hostvars[groups['ascender'][0]].ansible_host }}:{{ ascender_service.resources[0].spec.ports[0].nodePort }}/"
+- name: Display Ascender Login Info
+  ansible.builtin.import_playbook: info_ascender.yml

--- a/playbooks/install_ledger.yml
+++ b/playbooks/install_ledger.yml
@@ -9,26 +9,5 @@
     - k8s
     - ledger_install
 
-  tasks:
-    - name: Get the Admin password
-      kubernetes.core.k8s_info:
-        api: v1
-        kind: Secret
-        name: admin-password
-        namespace: "{{ LEDGER_NAMESPACE }}"
-      register: ledger_password
-
-    - name: Get the Service Port
-      kubernetes.core.k8s_info:
-        api: v1
-        kind: Service
-        name: web-svc
-        namespace: "{{ LEDGER_NAMESPACE }}"
-      register: ledger_service
-
-    - name: Display results
-      ansible.builtin.debug:
-        msg:
-          - "LEDGER USERNAME: admin"
-          - "LEDGER PASSWORD: {{ ledger_password.resources[0].data['admin-password'] | b64decode }}"
-          - "LEDGER URL: http://{{ hostvars[groups['ledger'][0]].ansible_host }}:{{ ledger_service.resources[0].spec.ports[0].nodePort }}/"
+- name: Display Ledger Login Info
+  ansible.builtin.import_playbook: info_ledger.yml

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -13,3 +13,8 @@
 - name: Configure Initial Playbooks
   ansible.builtin.import_playbook: setup_playbooks.yml
 
+- name: Display Ascender Login Info
+  ansible.builtin.import_playbook: info_ascender.yml
+
+- name: Display Ledger Login Info
+  ansible.builtin.import_playbook: info_ledger.yml


### PR DESCRIPTION
This moves the info dump into their own playbooks so we can include them at the end.  Stops you from having to search through the output to find the login info.