### PR TITLE
Relative path fix for vars_files in playbooks/backup.yml

### DIFF
--- a/playbooks/backup.yml
+++ b/playbooks/backup.yml
@@ -8,7 +8,7 @@
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/config"
 
   vars_files:
-    - ["custom.config.yml", "default.config.yml"]
+    - ["../custom.config.yml", "../default.config.yml"]
 
   tasks:
 


### PR DESCRIPTION
Updates the following expression in `./playbooks/backup.yml` from:
```yaml
vars_files:
  - ["custom.config.yml", "default.config.yml"]
```
to:
```yaml
vars_files:
  - ["../custom.config.yml", "../default.config.yml"]
```
This remediates the error:
```console
[root@myhost ascender-install]# ./setup.sh -b
Using Inventory File: ./inventory
BACKUP
[WARNING]: Found both group and host with same name: localhost

PLAY [localhost] **************************************************************************************************************************************
ERROR! vars file ['custom.config.yml', 'default.config.yml'] was not found
Could not find file on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option
```
