### PR TITLE
Fixes ascender operator version prompt

### DIFF
--- a/config_vars.sh
+++ b/config_vars.sh
@@ -404,7 +404,7 @@ echo "ASCENDER_VERSION: "$ascender_version >> custom.config.yml
 echo $'\n'
 echo "# The version of the AWX Operator used to install Ascender and its components" >> custom.config.yml
 read -p "The version of the AWX Operator used to install Ascender and its components [2.13.1]: " a_operator_version
-ascender_operator_version=${a_version:-2.13.1}
+ascender_operator_version=${a_operator_version:-2.13.1}
 echo "ANSIBLE_OPERATOR_VERSION: "$ascender_operator_version >> custom.config.yml
 
 # ascender_garbage_collect_secrets


### PR DESCRIPTION
This fixes issue #88 which was pulling the Ascender version into the operator version in the custom config