### PR TITLE
Fixes dictionary conditional error

### DIFF
--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_rke2.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_rke2.yml
@@ -20,7 +20,7 @@
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
     name: Default
     state: exists
-  until: org.id == 1
+  until: org.id is defined and org.id == 1
   retries: 200
   delay: 10
   register: org


### PR DESCRIPTION
This commit fixes an error where the playbook is checking for 'org.id == 1' but 'id' has not been created yet and thus fails.

```
TASK [setup_playbooks : Wait until Ascender API is Up and the Database is populated] *************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'org.id == 1' failed. The error was: error while evaluating conditional (org.id == 1): 'dict object' has no attribute 'id'. 'dict object' has no attribute 'id'"}
```

The fix waits for org.id to be 1 but also waits for id to be defined within org

This is the same code as on `ascender_credentials_k3s.yml`