### PR TITLE
Hardening playbooks now require the authselect profile to be set

### DIFF
--- a/playbooks/roles/setup_playbooks/tasks/templates.yml
+++ b/playbooks/roles/setup_playbooks/tasks/templates.yml
@@ -14,6 +14,7 @@
     survey_spec: "{% if template.survey_file is defined %}{{ lookup('file', template.survey_file) }}{% else %}{{ ''| default(omit, true) }}{% endif %}"
     ask_credential_on_launch: "{{ template.ask_credential_on_launch | default(omit) }}"
     diff_mode: "{{ template.diff_mode | default(omit) }}"
+    extra_vars: "{{ template.extra_vars | default(omit) }}"
     validate_certs: false
   register: result
   until: result is succeeded

--- a/playbooks/roles/setup_playbooks/vars/main.yml
+++ b/playbooks/roles/setup_playbooks/vars/main.yml
@@ -64,6 +64,8 @@ templates:
     playbook: site.yml
     ask_credential_on_launch: true
     diff_mode: true
+    extra_vars:
+      rhel9cis_set_boot_pass: false
 
   - name: CIS Benchmark Hardening for Enterprise Linux 8
     description: CIS Benchmark Hardening for Enterprise Linux 8
@@ -73,6 +75,8 @@ templates:
     playbook: site.yml
     ask_credential_on_launch: true
     diff_mode: true
+    extra_vars:
+      rhel8cis_allow_authselect_updates: false
 
   - name: STIG Hardening for Enterprise Linux 8
     description: STIG Hardening for Enterprise Linux 8


### PR DESCRIPTION
Disable authselect by default, user will need to set proper variables based upon their systems.
