### PR TITLE
Add usage of auth token for Ledger Pro

### DIFF
--- a/playbooks/roles/ledger_install/tasks/ledger_install_aks.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_aks.yml
@@ -165,15 +165,90 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
     controller_username: "{{ ASCENDER_ADMIN_USER }}"
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
+    validate_certs: false
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"

--- a/playbooks/roles/ledger_install/tasks/ledger_install_dkp.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_dkp.yml
@@ -108,6 +108,79 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
@@ -117,7 +190,8 @@
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"

--- a/playbooks/roles/ledger_install/tasks/ledger_install_eks.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_eks.yml
@@ -193,16 +193,90 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
     controller_username: "{{ ASCENDER_ADMIN_USER }}"
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
+    validate_certs: false
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
-    validate_certs: false
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"

--- a/playbooks/roles/ledger_install/tasks/ledger_install_gke.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_gke.yml
@@ -178,16 +178,90 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
     controller_username: "{{ ASCENDER_ADMIN_USER }}"
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
+    validate_certs: false
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
-    validate_certs: false
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"

--- a/playbooks/roles/ledger_install/tasks/ledger_install_k3s.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_k3s.yml
@@ -113,7 +113,7 @@
 
     - name: Check Ledger Token
       ansible.builtin.uri:
-        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
         user: admin
         password: "{{ LEDGER_ADMIN_PASSWORD }}"
         force_basic_auth: true
@@ -128,7 +128,7 @@
 
     - name: Regenerate Token if blank
       ansible.builtin.uri:
-        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/?regenerate_auth_token=1"
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
         user: admin
         password: "{{ LEDGER_ADMIN_PASSWORD }}"
         force_basic_auth: true
@@ -144,7 +144,7 @@
 
     - name: Get Ledger Token Again (in case of regeneration)
       ansible.builtin.uri:
-        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
         user: admin
         password: "{{ LEDGER_ADMIN_PASSWORD }}"
         force_basic_auth: true
@@ -162,7 +162,7 @@
 
     - name: Enable Require Token
       ansible.builtin.uri:
-        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
         user: admin
         password: "{{ LEDGER_ADMIN_PASSWORD }}"
         force_basic_auth: true

--- a/playbooks/roles/ledger_install/tasks/ledger_install_k3s.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_k3s.yml
@@ -108,6 +108,79 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ascender_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
@@ -117,7 +190,8 @@
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"

--- a/playbooks/roles/ledger_install/tasks/ledger_install_rke2.yml
+++ b/playbooks/roles/ledger_install/tasks/ledger_install_rke2.yml
@@ -111,6 +111,79 @@
 - ansible.builtin.debug:
     msg: "Ascender API is up"
 
+- when: LEDGER_REGISTRY.BASE is defined and LEDGER_REGISTRY.BASE != ""
+  block:
+
+    - name: Check Ledger Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - name: Regenerate Token if blank
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/?regenerate_auth_token=1"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings2
+      when: ledger_settings.json.auth_token is undefined
+
+    - name: Get Ledger Token Again (in case of regeneration)
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      register: ledger_settings
+
+    - debug:
+        var: ledger_settings.json.auth_token
+
+    - name: Enable Require Token
+      ansible.builtin.uri:
+        url: "{{ k8s_lb_protocol }}://{{ ledger_ip }}:{{ ledger_port }}/api/v1/settings/"
+        user: admin
+        password: "{{ LEDGER_ADMIN_PASSWORD }}"
+        force_basic_auth: true
+        method: POST
+        body_format: json
+        body: '{ "require_auth_token": 1 }'
+        return_content: yes
+        validate_certs: no
+        status_code:
+          - 200
+      until: uri_output.status == 200
+      retries: 60
+      delay: 10
+      when:
+        - ledger_settings.json.auth_token is defined
+        - ledger_settings.json.require_auth_token == 0
+      register: test
+
 - name: Set all the logging parameters
   awx.awx.settings:
     controller_host: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}"
@@ -120,7 +193,8 @@
     settings:
       LOG_AGGREGATOR_HOST: "{{ k8s_lb_protocol }}://{{ ledger_parser_ip }}"
       LOG_AGGREGATOR_PORT: "{{ ledger_parser_port }}"
-      LOG_AGGREGATOR_TYPE: other
+      LOG_AGGREGATOR_TYPE: ledger
       LOG_AGGREGATOR_ENABLED: true
       LOG_AGGREGATOR_VERIFY_CERT: false
       LOG_AGGREGATOR_LEVEL: INFO
+      LOG_AGGREGATOR_PASSWORD: "{{ ledger_settings.json.auth_token | default(omit, true) }}"


### PR DESCRIPTION

If Ledger Pro is installed, it will now setup the token authorization between Ascender and Ledger.

1) Check for token
2) Regenerate if blank
3) Get token and require_auth_token setting
4) Enable require_auth_token if unchecked
5) Update Ascender with Token and set logger to "ledger"