### PR TITLE
Add hop node for Mesh

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -201,6 +201,9 @@ ASCENDER_VERSION: 25.0.0
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1
 
+# DNS resolvable hostname for Ascender Mesh service.  This is used by Execution Nodes to access Ascender.
+ASCENDER_MESH_HOSTNAME: mesh.ascender.example.com
+
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true
 

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -172,6 +172,9 @@ ASCENDER_VERSION: 25.0.0
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1
 
+# DNS resolvable hostname for Ascender Mesh service.  This is used by Execution Nodes to access Ascender.
+ASCENDER_MESH_HOSTNAME: mesh.ascender.example.com
+
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true
 

--- a/playbooks/roles/ascender_install/templates/ascender-deployment/ascender-deployment-k3s.yml
+++ b/playbooks/roles/ascender_install/templates/ascender-deployment/ascender-deployment-k3s.yml
@@ -100,3 +100,17 @@ spec:
     value:
       - http://{{ ASCENDER_HOSTNAME }}
       - https://{{ ASCENDER_HOSTNAME }}
+---
+apiVersion: awx.ansible.com/v1alpha1
+kind: AWXMeshIngress
+metadata:
+  name: ascender-app-mesh
+  namespace: {{ ASCENDER_NAMESPACE }}
+spec:
+  deployment_name: ascender-app
+  ingress_type: IngressRouteTCP
+  ingress_controller: traefik
+  ingress_class_name: traefik
+  ingress_api_version: traefik.io/v1alpha1
+  external_hostname: {{ ASCENDER_MESH_HOSTNAME }}
+


### PR DESCRIPTION
In order for Execution Nodes to communicate with Ascender, we must install a Mesh Hop node.  It must have a unique URL.