### PR TITLE
Add config options for altering the default postgres storage mechanisms.

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -226,6 +226,14 @@ ascender_setup_playbooks: true
 # # External PostgreSQL database name used for Ascender (this DB must exist)
 # ASCENDER_PGSQL_DB: ascenderdb
 
+# # Used to increase the default size of the Postgres Storage PVC.
+# # !!! Do not set or change this for an existing install !!!
+# # The Operator does not currently handle increasing sizes, must be done manually if your StorageClass allows
+# POSTGRES_PVC_SIZE_GB: 8
+
+# # Set the Storage Class for your PVC
+# # !!! Do not set or change this for an existing install !!!
+# POSTGRES_STORAGE_CLASS: local-path
 
 ### All of these options are unnecessary to change, but will allow you to tweak your Ascender deployment if you choose to change them
 ascender_replicas: 1

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -197,6 +197,15 @@ ascender_setup_playbooks: true
 # # External PostgreSQL database name used for Ascender (this DB must exist)
 # ASCENDER_PGSQL_DB: ascenderdb
 
+# # Used to increase the default size of the Postgres Storage PVC.
+# # !!! Do not set or change this for an existing install !!!
+# # The Operator does not currently handle increasing sizes, must be done manually if your StorageClass allows
+# POSTGRES_PVC_SIZE_GB: 8
+
+# # Set the Storage Class for your PVC
+# # !!! Do not set or change this for an existing install !!!
+# POSTGRES_STORAGE_CLASS: local-path
+
 ### All of these options are unnecessary to change, but will allow you to tweak your Ascender deployment if you choose to change them
 ascender_replicas: 1
 ascender_image_pull_policy: Always

--- a/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
+++ b/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
@@ -20,6 +20,14 @@
      - 'shared_buffers=256MB'
      - '-c'
      - 'max_connections=1000'
+{% if POSTGRES_PVC_SIZE_GB is defined %}
+  postgres_storage_requirements:
+    requests:
+      storage: {{ POSTGRES_PVC_SIZE_GB }}Gi
+{% endif %}
+{% if POSTGRES_STORAGE_CLASS is defined %}
+  postgres_storage_class: {{ POSTGRES_STORAGE_CLASS }}
+{% endif %}
   redis_image: {{ k8s_container_registry | default("docker.io", true)  ~ "/redis" }}
   redis_image_version: "7"
 {% if k8s_image_pull_secret is defined and k8s_image_pull_secret != 'None' %}


### PR DESCRIPTION
These can not be changed after initial install.

The default storage class for k3s is "local-path" which doesn't allow expanding PVCs after creation.  This option will allow us to also install Longhorn or any other StorageClass which are a bit more robust.