### PR TITLE
Update to Ascender 25.2.0

### DIFF
--- a/config_vars.sh
+++ b/config_vars.sh
@@ -561,15 +561,15 @@ echo "ASCENDER_ADMIN_PASSWORD: "\"$ascender_admin_password\" >> custom.config.ym
 # ASCENDER_VERSION
 echo $'\n'
 echo "# The image tag indicating the version of Ascender you wish to install" >> custom.config.yml
-read -p "The image tag indicating the version of Ascender you wish to install [24.0.0]: " a_version
-ascender_version=${a_version:-25.1.0}
+read -p "The image tag indicating the version of Ascender you wish to install [25.2.0]: " a_version
+ascender_version=${a_version:-25.2.0}
 echo "ASCENDER_VERSION: "$ascender_version >> custom.config.yml
 
 # ANSIBLE_OPERATOR_VERSION
 echo $'\n'
 echo "# The version of the AWX Operator used to install Ascender and its components" >> custom.config.yml
-read -p "The version of the AWX Operator used to install Ascender and its components [2.19.0]: " a_operator_version
-ascender_operator_version=${a_operator_version:-2.19.0}
+read -p "The version of the AWX Operator used to install Ascender and its components [2.19.1]: " a_operator_version
+ascender_operator_version=${a_operator_version:-2.19.1}
 echo "ANSIBLE_OPERATOR_VERSION: "$ascender_operator_version >> custom.config.yml
 
 # ascender_garbage_collect_secrets

--- a/default.config.yml
+++ b/default.config.yml
@@ -198,7 +198,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
     # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
     # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1

--- a/docs/configuration/upgrading.md
+++ b/docs/configuration/upgrading.md
@@ -30,10 +30,10 @@ download_kubeconfig: false
 You already have a working kubeconfig and don't need to re-download it.
 
 ```yaml
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 ```
 
-Replace `25.1.0` with the version you want to upgrade to. The list of available versions is here: 
+Replace `25.2.0` with the version you want to upgrade to. The list of available versions is here: 
 
 [Ascender Releases](https://github.com/ctrliq/ascender/releases)
 
@@ -104,6 +104,6 @@ kubectl rollout restart deployment/ascender-app-task -n ascender
 ```bash
 kube_install: false  
 download_kubeconfig: false  
-ASCENDER_VERSION: 25.1.0  
+ASCENDER_VERSION: 25.2.0  
 image_pull_policy: Always
 ```

--- a/docs/installation/aks/aks.custom.config.yml
+++ b/docs/installation/aks/aks.custom.config.yml
@@ -51,7 +51,7 @@ ASCENDER_ADMIN_USER: admin
 # Administrator password for Ascender
 ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)

--- a/docs/installation/dkp/dkp.default.config.yml
+++ b/docs/installation/dkp/dkp.default.config.yml
@@ -50,10 +50,10 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.5.2
+ANSIBLE_OPERATOR_VERSION: 2.19.1
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/eks/eks.custom.config.yml
+++ b/docs/installation/eks/eks.custom.config.yml
@@ -108,10 +108,10 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.7.0
+ANSIBLE_OPERATOR_VERSION: 2.19.1
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/gke/gke.custom.config.yml
+++ b/docs/installation/gke/gke.custom.config.yml
@@ -47,9 +47,9 @@ ASCENDER_ADMIN_USER: admin
 # Administrator password for Ascender
 ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.0
+ANSIBLE_OPERATOR_VERSION: 2.19.1
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: false
 # External PostgreSQL database name used for Ascender (this DB must exist)

--- a/docs/installation/k3s/k3s.default.config.yml
+++ b/docs/installation/k3s/k3s.default.config.yml
@@ -89,7 +89,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1

--- a/docs/installation/k3s/k3s.offline.default.config.yml
+++ b/docs/installation/k3s/k3s.offline.default.config.yml
@@ -89,7 +89,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1

--- a/docs/installation/rke2/rke2.default.config.yml
+++ b/docs/installation/rke2/rke2.default.config.yml
@@ -37,9 +37,9 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 # The OCI container image for Ascender
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.9.0
+ANSIBLE_OPERATOR_VERSION: 2.19.1
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: false
 # External PostgreSQL database name used for Ascender (this DB must exist)

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -167,7 +167,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 
 # The image tag indicating the version of Ascender you wish to install
-ASCENDER_VERSION: 25.1.0
+ASCENDER_VERSION: 25.2.0
 
 # The version of the AWX Operator used to install Ascender and its components
 ANSIBLE_OPERATOR_VERSION: 2.19.1

--- a/playbooks/roles/ascender_install/defaults/main.yml
+++ b/playbooks/roles/ascender_install/defaults/main.yml
@@ -24,6 +24,6 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: latest
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: latest
+ANSIBLE_OPERATOR_VERSION: 2.19.1
 
 k8s_container_registry: ghcr.io/ctrliq

--- a/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
+++ b/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
@@ -3,7 +3,7 @@
 {% else %}
   image: {{ ASCENDER_IMAGE }}
 {% endif %}
-  image_version: {{ ASCENDER_VERSION | default("25.1.0") }}
+  image_version: {{ ASCENDER_VERSION | default("25.2.0") }}
 {% if k8s_platform == "k3s" and k8s_offline | default (false) | bool %}
   image_pull_policy: Never
 {% else %}


### PR DESCRIPTION
Changes all Ascender versions to 25.2.0
Fixes Operator versions across all docs / configs