### PR TITLE
Update redis image reference to use 'valkey' instead of 'redis'

### DIFF
--- a/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
+++ b/playbooks/roles/ascender_install/templates/ascender-deployment/additional-spec.yml
@@ -28,7 +28,7 @@
 {% if POSTGRES_STORAGE_CLASS is defined %}
   postgres_storage_class: {{ POSTGRES_STORAGE_CLASS }}
 {% endif %}
-  redis_image: {{ k8s_container_registry | default("ghcr.io/valkey-io", true)  ~ "/redis" }}
+  redis_image: {{ k8s_container_registry | default("ghcr.io/valkey-io", true)  ~ "/valkey" }}
   redis_image_version: "9-alpine"
 {% if k8s_image_pull_secret is defined and k8s_image_pull_secret != 'None' %}
   image_pull_secret: {{ k8s_image_pull_secret }}


### PR DESCRIPTION
This initially resolved to:

```
ghcr.io/valkey-io/redis
```

This corrects it to resolve to:

```
ghcr.io/valkey-io/valkey
```