### PR TITLE
Swap to using our fork of the AWX Operator

### DIFF
--- a/config_vars.sh
+++ b/config_vars.sh
@@ -578,12 +578,12 @@ read -p "The image tag indicating the version of Ascender you wish to install [2
 ascender_version=${a_version:-25.3.2}
 echo "ASCENDER_VERSION: "$ascender_version >> custom.config.yml
 
-# ANSIBLE_OPERATOR_VERSION
+# ASCENDER_OPERATOR_VERSION
 echo $'\n'
 echo "# The version of the AWX Operator used to install Ascender and its components" >> custom.config.yml
-read -p "The version of the AWX Operator used to install Ascender and its components [2.19.1]: " a_operator_version
-ascender_operator_version=${a_operator_version:-2.19.1}
-echo "ANSIBLE_OPERATOR_VERSION: "$ascender_operator_version >> custom.config.yml
+read -p "The version of the AWX Operator used to install Ascender and its components [2.19.2]: " a_operator_version
+ascender_operator_version=${a_operator_version:-2.19.2}
+echo "ASCENDER_OPERATOR_VERSION: "$ascender_operator_version >> custom.config.yml
 
 # ascender_garbage_collect_secrets
 echo $'\n'

--- a/default.config.yml
+++ b/default.config.yml
@@ -201,7 +201,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
     # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
     # DNS resolvable hostname for Ascender Mesh service.  This is used by Execution Nodes to access Ascender.
     # Mesh will not be setup unless this is configured

--- a/docs/installation/aks/aks.custom.config.yml
+++ b/docs/installation/aks/aks.custom.config.yml
@@ -53,7 +53,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 # The image tag indicating the version of Ascender you wish to install
 ASCENDER_VERSION: 25.3.2
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: false
 # External PostgreSQL database name used for Ascender (this DB must exist)

--- a/docs/installation/dkp/dkp.default.config.yml
+++ b/docs/installation/dkp/dkp.default.config.yml
@@ -53,7 +53,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/eks/eks.custom.config.yml
+++ b/docs/installation/eks/eks.custom.config.yml
@@ -111,7 +111,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/gke/gke.custom.config.yml
+++ b/docs/installation/gke/gke.custom.config.yml
@@ -49,7 +49,7 @@ ASCENDER_ADMIN_PASSWORD: "myadminpassword"
 # The image tag indicating the version of Ascender you wish to install
 ASCENDER_VERSION: 25.3.2
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: false
 # External PostgreSQL database name used for Ascender (this DB must exist)

--- a/docs/installation/k3s/k3s.default.config.yml
+++ b/docs/installation/k3s/k3s.default.config.yml
@@ -92,7 +92,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/k3s/k3s.offline.default.config.yml
+++ b/docs/installation/k3s/k3s.offline.default.config.yml
@@ -92,7 +92,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: true

--- a/docs/installation/rke2/rke2.default.config.yml
+++ b/docs/installation/rke2/rke2.default.config.yml
@@ -39,7 +39,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 # The image tag indicating the version of Ascender you wish to install
 ASCENDER_VERSION: 25.3.2
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 # Determines whether to keep the secrets required to encrypt within Ascender (important when backing up)
 ascender_garbage_collect_secrets: false
 # External PostgreSQL database name used for Ascender (this DB must exist)

--- a/playbooks/create_bundle.yml
+++ b/playbooks/create_bundle.yml
@@ -24,7 +24,7 @@
         type: ledger
       - name: awx-operator
         path: quay.io/ansible/awx-operator
-        tag: "{{ ANSIBLE_OPERATOR_VERSION }}"
+        tag: "{{ ASCENDER_OPERATOR_VERSION }}"
         type: ascender
       - name: ascender-ee
         path: ghcr.io/ctrliq/ascender-ee
@@ -99,12 +99,12 @@
 
     - name: Remove Operator if Exists
       ansible.builtin.file:
-        path: "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}"
+        path: "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}"
         state: absent
 
     - name: Download the Ansible Operator tar file
       ansible.builtin.get_url:
-        url: https://api.github.com/repos/ansible/awx-operator/tarball/{{ ANSIBLE_OPERATOR_VERSION }}
+        url: https://api.github.com/repos/ansible/awx-operator/tarball/{{ ASCENDER_OPERATOR_VERSION }}
         dest: "{{ offline_dir }}/awx-operator.tar"
 
     - name: Extract Ansible Operator tar
@@ -121,32 +121,32 @@
 
     - name: Rename the directory
       ansible.builtin.command:
-        cmd: mv "{{ ops.files[0].path }}" "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}"
+        cmd: mv "{{ ops.files[0].path }}" "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}"
       when: ops.matched == 1
 
     - name: Fix the Operator Version
       ansible.builtin.lineinfile:
-        path: "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config/manager/kustomization.yaml"
+        path: "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config/manager/kustomization.yaml"
         search_string: 'newTag: latest'
-        line: "  newTag: {{ ANSIBLE_OPERATOR_VERSION }}"
+        line: "  newTag: {{ ASCENDER_OPERATOR_VERSION }}"
 
     - name: Fix the Pull Policy
       ansible.builtin.lineinfile:
-        path: "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config/manager/manager.yaml"
+        path: "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config/manager/manager.yaml"
         search_string: 'imagePullPolicy:'
         line: "        imagePullPolicy: Never"
       when: k8s_platform == 'k3s'
 
     - name: Fix the awx-operator image path
       ansible.builtin.lineinfile:
-        path: "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config/manager/kustomization.yaml"
+        path: "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config/manager/kustomization.yaml"
         search_string: 'quay.io/ansible/awx-operator'
         line: "  newName: {{ k8s_container_registry | regex_replace('\\/$', '') }}/awx-operator"
       when: k8s_platform == 'rke2'
 
     - name: Fix the kube-rbac-proxy image path
       ansible.builtin.lineinfile:
-        path: "{{ offline_dir }}/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config/default/manager_auth_proxy_patch.yaml"
+        path: "{{ offline_dir }}/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config/default/manager_auth_proxy_patch.yaml"
         search_string: 'gcr.io/kubebuilder/kube-rbac-proxy'
         line: "        image: {{ k8s_container_registry | regex_replace('\\/$', '') }}/kube-rbac-proxy:v0.15.0"
       when: k8s_platform == 'rke2'

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -170,7 +170,7 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: 25.3.2
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 # DNS resolvable hostname for Ascender Mesh service.  This is used by Execution Nodes to access Ascender.
 # Mesh will not be setup unless this is configured

--- a/playbooks/roles/ascender_install/defaults/main.yml
+++ b/playbooks/roles/ascender_install/defaults/main.yml
@@ -24,6 +24,6 @@ ASCENDER_IMAGE: ghcr.io/ctrliq/ascender
 ASCENDER_VERSION: latest
 
 # The version of the AWX Operator used to install Ascender and its components
-ANSIBLE_OPERATOR_VERSION: 2.19.1
+ASCENDER_OPERATOR_VERSION: 2.19.2
 
 k8s_container_registry: ghcr.io/ctrliq

--- a/playbooks/roles/ascender_install/tasks/ascender_install_aks.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_aks.yml
@@ -29,7 +29,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when:

--- a/playbooks/roles/ascender_install/tasks/ascender_install_dkp.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_dkp.yml
@@ -23,7 +23,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when:

--- a/playbooks/roles/ascender_install/tasks/ascender_install_eks.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_eks.yml
@@ -29,7 +29,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when:

--- a/playbooks/roles/ascender_install/tasks/ascender_install_gke.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_gke.yml
@@ -29,7 +29,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when:

--- a/playbooks/roles/ascender_install/tasks/ascender_install_k3s.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_k3s.yml
@@ -23,7 +23,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when: k8s_offline | default(false) | bool

--- a/playbooks/roles/ascender_install/tasks/ascender_install_ocp.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_ocp.yml
@@ -23,7 +23,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when: k8s_offline | default(false) | bool

--- a/playbooks/roles/ascender_install/tasks/ascender_install_rke2.yml
+++ b/playbooks/roles/ascender_install/tasks/ascender_install_rke2.yml
@@ -23,7 +23,7 @@
 
 - name: Copy Operator Source
   ansible.builtin.copy:
-    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ANSIBLE_OPERATOR_VERSION }}/config"
+    src: "{{ playbook_dir }}/../offline/awx-operator-{{ ASCENDER_OPERATOR_VERSION }}/config"
     dest: "{{ tmp_dir }}/"
     remote_src: true
   when:

--- a/playbooks/roles/ascender_install/templates/awx-operator/kustomization.j2
+++ b/playbooks/roles/ascender_install/templates/awx-operator/kustomization.j2
@@ -6,13 +6,13 @@ resources:
 {% if k8s_offline | default(false) | bool %}
   - ./config/default
 {% else %}
-  - github.com/ansible/awx-operator/config/default?ref={{ ANSIBLE_OPERATOR_VERSION }}
+  - github.com/ctrliq/ascender-operator/config/default?ref={{ ASCENDER_OPERATOR_VERSION }}
 {% endif %}
 
 # Set the image tags to match the git version from above
 images:
-  - name: {{ k8s_container_registry | default("quay.io/ansible", true)  ~ "/awx-operator" }} 
-    newTag: {{ ANSIBLE_OPERATOR_VERSION }}
+  - name: {{ k8s_container_registry | default("ghcr.io/ctrliq", true)  ~ "/ascender-operator" }}
+    newTag: {{ ASCENDER_OPERATOR_VERSION }}
 
 # Specify a custom namespace in which to install AWX
 namespace: {{ ASCENDER_NAMESPACE }}


### PR DESCRIPTION
Take note, we changed the variable in the config file on purpose from ANSIBLE_OPERATOR_VERSION to ASCENDER_OPERATOR_VERSION.  The reasoning behind this is if someone is using an older config file with the older variable, it will attempt to pull a non-existent version of the new operator.  We could combat this by releasing a version of each of the old versions, but its easier to do it this way.  This way, it will instead use the default of the new version with the new operator.  When they update their config, then they can pick a specific version of the operator if they like.