### PR TITLE
Fix ansible_user undefined error in GKE and AKS Terraform tasks

### DIFF
--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_aks.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_aks.yml
@@ -76,7 +76,7 @@
         project_path: "{{ playbook_dir }}/../ascender_install_artifacts/aks_deploy"
         state: present
         variables:
-          home_dir: "/home/{{ ansible_user}}"
+          home_dir: "{{ ansible_env.HOME }}"
           aks_cluster_name: "{{ AKS_CLUSTER_NAME }}"
           resource_group_location: "{{ AKS_CLUSTER_REGION }}"
           node_count: "{{ AKS_NUM_WORKER_NODES }}"

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_gke.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_gke.yml
@@ -84,7 +84,7 @@
         project_path: "{{ playbook_dir }}/../ascender_install_artifacts/gke_deploy"
         state: present
         variables:
-          home_dir: "/home/{{ ansible_user}}"
+          home_dir: "{{ ansible_env.HOME }}"
           gke_cluster_name: "{{ GKE_CLUSTER_NAME }}"
           kubernetes_version: "{{ GKE_K8S_VERSION }}"
           project_id: "{{ GKE_PROJECT_ID }}"


### PR DESCRIPTION
When `ansible_connection=local` is used, `ansible_user` is never set and referencing it causes an immediate failure. Replace `/home/{{ ansible_user }}` with `{{ ansible_env.HOME }}` which resolves correctly in local connections.