### PR TITLE
Add revisionHistoryLimit to Ledger

### DIFF
--- a/playbooks/roles/ledger_install/templates/ledger_deployment_aks.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_aks.yaml
@@ -159,6 +159,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -238,6 +239,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -301,6 +303,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_dkp.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_dkp.yaml
@@ -169,6 +169,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -248,6 +249,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -311,6 +313,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_eks.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_eks.yaml
@@ -155,6 +155,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -234,6 +235,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -297,6 +299,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_gke.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_gke.yaml
@@ -159,6 +159,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -238,6 +239,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -301,6 +303,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_k3s.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_k3s.yaml
@@ -185,6 +185,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -268,6 +269,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -336,6 +338,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_ocp.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_ocp.yaml
@@ -174,6 +174,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -252,6 +253,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -319,6 +321,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:

--- a/playbooks/roles/ledger_install/templates/ledger_deployment_rke2.yaml
+++ b/playbooks/roles/ledger_install/templates/ledger_deployment_rke2.yaml
@@ -168,6 +168,7 @@ metadata:
   name: db
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:
@@ -247,6 +248,7 @@ metadata:
   name: parser
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_parser_replicas }}
   selector:
     matchLabels:
@@ -310,6 +312,7 @@ metadata:
   name: web
   namespace: {{ LEDGER_NAMESPACE }}
 spec:
+  revisionHistoryLimit: 1
   replicas: {{ ledger_web_replicas }}
   selector:
     matchLabels:


### PR DESCRIPTION
Default for keeping old replicasets around is 10, lets drop that down to 1 so we aren't keeping so many old ones around.