### PR TITLE
Fix RBAC and operator bring-up on AWX->Ascender migration 

### DIFF
--- a/playbooks/roles/awx_migrate_ascender/tasks/patch_cr.yml
+++ b/playbooks/roles/awx_migrate_ascender/tasks/patch_cr.yml
@@ -3,10 +3,26 @@
 # Must run BEFORE operator startup so it reconciles with the updated spec.
 # Driven by cr_patch list in vars/main.yml.
 
+- name: Check whether the LDAP CA cert secret exists
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: ldap-ca-crt
+    namespace: "{{ ascender.namespace }}"
+  register: _ldap_secret
+
+# ldap_cacert_secret points the operator at a secret it will load and mount. If
+# the backup had no LDAP CA cert (optional), that secret was never created, and
+# patching the field makes the operator reconcile fail on "Load LDAP CA
+# Certificate Secret" and never bring Ascender up. Drop it when absent.
+- name: Drop ldap_cacert_secret from the patch when its secret is absent
+  ansible.builtin.set_fact:
+    cr_patch_effective: "{{ cr_patch if (_ldap_secret.resources | length > 0) else (cr_patch | rejectattr('field', 'equalto', 'ldap_cacert_secret') | list) }}"
+
 - name: Build CR patch
   ansible.builtin.set_fact:
     _cr_patch: "{{ _cr_patch | default({}) | combine({item.field: item.value | default(awx_object_spec[item.field])}) }}"
-  loop: "{{ cr_patch }}"
+  loop: "{{ cr_patch_effective }}"
   when: item.value is defined or (awx_object_spec is defined and awx_object_spec[item.field] is defined)
 
 - name: Show CR patch

--- a/playbooks/roles/awx_migrate_ascender/templates/awx_migrate.sh.j2
+++ b/playbooks/roles/awx_migrate_ascender/templates/awx_migrate.sh.j2
@@ -21,4 +21,29 @@ awx-manage migrate dab_resource_registry --noinput
 # Tables were cleared by migration_fix.sh.j2 so data migrations find zero rows.
 awx-manage migrate dab_rbac --noinput
 
+# Reconcile derived RBAC state the bulk pg_restore left stale. A SQL-level
+# restore fires no Django ORM signals, so the role ancestor cache, implicit
+# role parents, and superuser membership in the system_administrator singleton
+# arrive cold from an AWX 24.6.x database. Without this, job template access
+# lists and the team/user role views render empty even though grants restored
+# intact. Idempotent; only ever adds superusers.
+awx-manage shell <<'PYEOF'
+from django.apps import apps
+from django.contrib.auth.models import User
+from awx.main.models.rbac import Role, ROLE_SINGLETON_SYSTEM_ADMINISTRATOR
+from awx.main.migrations._rbac import rebuild_role_parentage, rebuild_role_hierarchy
+
+rebuild_role_parentage(apps, None)   # main_rbac_roles_parents + implicit_parents
+rebuild_role_hierarchy(apps, None)   # main_rbac_role_ancestors (full recompute)
+for u in User.objects.filter(is_superuser=True):
+    u.save(update_fields=['is_superuser'])  # fires sync_superuser_status_to_rbac
+
+sa = Role.singleton(ROLE_SINGLETON_SYSTEM_ADMINISTRATOR)
+supers = User.objects.filter(is_superuser=True).count()
+members = sa.members.count()
+print("RBAC reconcile complete: %d superusers, %d singleton members" % (supers, members))
+if supers > 0 and members == 0:
+    raise SystemExit("ERROR: system_administrator singleton has no members after reconcile")
+PYEOF
+
 echo "All Ascender migrations applied successfully."


### PR DESCRIPTION
Fix empty RBAC views and operator bring-up after AWX→Ascender migration (ZD #3094)

Two bugs found migrating a running AWX 24.6.x onto Ascender:

1. Roles/access-lists empty after migration. A SQL-level restore fires no ORM signals, so the legacy RBAC derived state (ancestor cache, implicit parents, system_administrator membership) arrives cold and Ascender renders empty role/access views despite intact grants. Fix: rebuild it after the migrations run (awx_migrate.sh.j2).

2. Operator won't start on a no-LDAP backup. ldap_cacert_secret was patched onto the CR unconditionally, but the secret is optional — so the operator fails loading a secret that doesn't exist. Fix: only patch it when the secret exists (patch_cr.yml).