### PR TITLE
fix: select the latest S3 backup without grep or awk

### DIFF
--- a/playbooks/roles/awx_migrate_ascender/templates/s3_download.sh.j2
+++ b/playbooks/roles/awx_migrate_ascender/templates/s3_download.sh.j2
@@ -1,9 +1,32 @@
 #!/bin/bash
 set -euo pipefail
 
-mc --config-dir /tmp/.mc alias set s3 '{{ s3.secret.endpoint }}' '{{ s3.secret.accesskey }}' '{{ s3.secret.secretkey }}'
+# The mc container image is a minimal image that ships without grep and awk, so the
+# most recent backup folder is selected with Bash builtins only, using the JSON
+# output of "mc ls". LC_ALL is pinned so the comparison below is byte ordered.
+export LC_ALL=C
 
-latest=$(mc --config-dir /tmp/.mc ls s3/{{ s3.secret.bucket }}/ | grep 'tower-' | sort | tail -n 1 | awk '{print $NF}')
+MC="mc --config-dir /tmp/.mc"
+
+$MC alias set s3 '{{ s3.secret.endpoint }}' '{{ s3.secret.accesskey }}' '{{ s3.secret.secretkey }}'
+
+listing=$($MC ls --json 's3/{{ s3.secret.bucket }}/')
+
+latest=""
+while IFS= read -r entry; do
+  case "$entry" in
+    *'"key":"tower-'*) ;;
+    *) continue ;;
+  esac
+
+  key=${entry#*'"key":"'}
+  key=${key%%'"'*}
+
+  if [[ "$key" > "$latest" ]]; then
+    latest="$key"
+  fi
+done <<< "$listing"
+
 if [ -z "$latest" ]; then
   echo "ERROR: No backup folders found"
   exit 1
@@ -11,4 +34,4 @@ fi
 
 echo "Downloading: $latest"
 rm -rf /backups/awx-prod
-mc --config-dir /tmp/.mc cp --recursive s3/{{ s3.secret.bucket }}/$latest /backups/awx-prod/
+$MC cp --recursive "s3/{{ s3.secret.bucket }}/$latest" /backups/awx-prod/


### PR DESCRIPTION
Closes #213.

## Problem

`minio/mc:latest` is now built on a minimal base image that no longer ships `grep` or `awk`, so the folder-selection pipeline in `s3_download.sh.j2` fails inside the worker pod:

```
bash: line 6: grep: command not found
bash: line 6: awk: command not found
```

The migration then aborts at `awx_migrate_ascender : Download latest AWX backup from S3`.

## Change

The latest `tower-*` backup folder is now selected with Bash builtins only, over the JSON output of `mc ls`:

- `mc ls --json` gives one JSON object per entry, and the `key` field is extracted with parameter expansion, so folder names containing spaces are handled correctly too.
- The newest folder is picked with a string comparison inside the loop, replacing `grep | sort | tail | awk`.
- `LC_ALL=C` is exported so that comparison is byte ordered regardless of the image locale.

`mc` itself is the only external command the script still relies on, so it no longer matters which base image the client is built from.

## Testing

Run against a MinIO server in Docker, seeded with three `tower-openshift-backup-*` folders (each holding `tower.db` and `secrets.yml`) plus one unrelated folder, executing both versions of the rendered script inside the real `minio/mc:latest` image.

The image confirms the report: `bash`, `mc`, `sort`, `tail` and `rm` are present, `grep` and `awk` are not.

`main`:

```
Added `s3` successfully.
/tmp/s3.sh: line 6: grep: command not found
/tmp/s3.sh: line 6: awk: command not found
exit code: 127
```

This branch:

```
Added `s3` successfully.
Downloading: tower-openshift-backup-2026-08-22-09:15:00/
`s3/awx-backups/tower-openshift-backup-2026-08-22-09:15:00/secrets.yml` -> `/backups/awx-prod/secrets.yml`
`s3/awx-backups/tower-openshift-backup-2026-08-22-09:15:00/tower.db` -> `/backups/awx-prod/tower.db`
exit code: 0
```

The newest of the three backups is selected and the unrelated folder is ignored. Two more checks on the same setup: against an empty bucket the script still prints `ERROR: No backup folders found` and exits 1, and the role's follow-up task, `test -f /backups/awx-prod/tower.db`, returns `found` after the download.

Not run as part of a full AWX to Ascender migration, since that needs a cluster with an AWX backup on S3.
