### PR TITLE
fix: stop writing /etc/hosts entries on OCP installs

### DIFF
--- a/docs/installation/ocp/README.md
+++ b/docs/installation/ocp/README.md
@@ -31,6 +31,11 @@ If you have not done so already, be sure to follow the general prerequisites fou
   - The installer will not set up OCP for you - you must have an existing, accessible cluster
   - Ensure you have administrative access to the cluster via `oc` or `kubectl` commands
   - The `kube_install` variable should be set to `false` for OCP installations
+- DNS Resolution
+  - Ascender and Ledger are published as OCP Routes, so `ASCENDER_HOSTNAME` and `LEDGER_HOSTNAME`
+    must resolve through the DNS server that serves your cluster's wildcard record
+  - The installer does not write `/etc/hosts` entries on OCP, so `use_etc_hosts` has no effect on
+    this platform
 - SSL Certificate and TLS Configuration
   - OpenShift Container Platform handles SSL/TLS termination through Routes
   - If you set `k8s_lb_protocol` to `http`, the installer will configure OCP Routes to use edge

--- a/docs/installation/ocp/ocp.basic.config.yml
+++ b/docs/installation/ocp/ocp.basic.config.yml
@@ -22,10 +22,6 @@ tls_crt_path: "~/ascender.crt"
     # TLS Private Key file, required when deploying HTTPS
 tls_key_path: "~/ascender.key"
 
-    # Set to false if using an external DNS server for resolution
-    # Set to true if not
-use_etc_hosts: true
-
     # DNS resolvable hostname for Ascender service. This is required for install.
 ASCENDER_HOSTNAME: ascender.example.com
 

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_ocp.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_ocp.yml
@@ -2,6 +2,11 @@
   ansible.builtin.wait_for_connection:
     delay: 15
 
+# OCP publishes Ascender and Ledger through Routes, which are resolved by the
+# cluster wildcard DNS record, so no local /etc/hosts entry is ever needed here.
+# Writing one pointed the installer at the wrong address and made the final
+# "Wait until Ascender API is Up" check fail with a connection refused error.
+
 - name: Get a list of all nodes
   kubernetes.core.k8s_info:
     api_version: v1
@@ -10,29 +15,3 @@
   delegate_to: localhost
   environment:
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/config"
-
-- name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ ASCENDER_HOSTNAME }}"
-    line: "{{ k3s_master_node_ip }}   {{ ASCENDER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: use_etc_hosts
-
-- name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ LEDGER_HOSTNAME }}"
-    line: "{{ k3s_master_node_ip }}   {{ LEDGER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when:
-    - use_etc_hosts
-    - LEDGER_INSTALL


### PR DESCRIPTION
Closes #191.

## Problem

On OCP the install fails at `Wait until Ascender API is Up`:

```
Status code was -1 and not [200]: Request failed: <urlopen error [Errno 111] Connection refused>
```

`use_etc_hosts` is only prompted for on `k3s`, `dkp`, `rke2` and `tkgi`, so on OCP it falls through to `use_etc_hosts: true` from `default.config.yml`. `k8s_setup_ocp.yml` honoured it and wrote

```
127.0.0.1   ascender.example.com
127.0.0.1   ledger.example.com
```

to the installer host, using `k3s_master_node_ip` (`127.0.0.1` by default) as the address. The final health check then hit localhost instead of the cluster ingress and retried 200 times before failing, even though the deployment itself was healthy.

## Change

This is option A from the issue: the `/etc/hosts` tasks are removed from `k8s_setup_ocp.yml`. OCP publishes Ascender and Ledger as Routes that resolve through the cluster wildcard DNS record, so a local host file entry on the installer host is never the right answer there, and pointing it at a k3s variable makes it actively harmful.

Also:

- `use_etc_hosts` is dropped from `docs/installation/ocp/ocp.basic.config.yml`, since it no longer does anything on this platform.
- The OCP prerequisites gain a short DNS section saying the hostnames must resolve through cluster DNS and that `use_etc_hosts` has no effect on OCP.

Nothing outside the OCP path changes: k3s, dkp, rke2 and tkgi keep their `/etc/hosts` handling and their prompt.

## Testing

Not run against a live OCP cluster, and I have no way to stand one up here. The change is the removal of two tasks on the OCP path plus docs; `ansible-playbook --syntax-check playbooks/setup.yml` passes on the branch. The removed tasks are the ones the issue identifies as writing the bad entries, and the reporter's workaround (`use_etc_hosts: false`) has the same effect as this patch.
