### PR TITLE
feat: allow Ubuntu 26 as an installer platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Ansible-driven installer that deploys [Ascender](https://github.com/ctrliq/as
 
 ## Requirements
 
-- Control machine on Enterprise Linux 8 or 9, or Ubuntu/Debian 24, `x86_64` only
+- Control machine on Enterprise Linux 8 or 9, or Ubuntu/Debian 24 or 26, `x86_64` only
   - Enterprise Linux covers Rocky, RHEL, Alma, CentOS, and Fedora
   - EL 9 is required when `k8s_platform` is `aks`, `gke`, or `eks`
   - Ubuntu and Debian are not supported for `aks`, `gke`, or `eks`

--- a/docs/installation/k3s/README.md
+++ b/docs/installation/k3s/README.md
@@ -25,7 +25,7 @@ If you have not done so already, be sure to follow the general prerequisites fou
   both master and worker node.
 - Operating System
   - If the OS family is Enterprise Linux (Rocky, Fedora, Alma, RHEL, or CentOS) then the major version must be 8 or 9.
-  - If the OS family is Ubuntu/Debian then the major version must be 24
+  - If the OS family is Ubuntu/Debian then the major version must be 24 or 26
 - Minimal System Requirements for the k3s server:
   - CPUs: 2
   - Memory: 8GB (if installing both Ascender and Ledger)

--- a/docs/installation/ocp/README.md
+++ b/docs/installation/ocp/README.md
@@ -22,7 +22,7 @@ If you have not done so already, be sure to follow the general prerequisites fou
   - The installer can run from any system with network access to your OCP cluster
   - Operating System
     - If the OS family is Enterprise Linux (Rocky, Fedora, Alma, RHEL, or CentOS) then the major version must be 8 or 9.
-    - If the OS family is Ubuntu/Debian then the major version must be 24
+    - If the OS family is Ubuntu/Debian then the major version must be 24 or 26
 - Minimal System Requirements for the OCP cluster:
   - CPUs: 2
   - Memory: 8GB (if installing both Ascender and Ledger)

--- a/playbooks/assertions.yml
+++ b/playbooks/assertions.yml
@@ -61,8 +61,8 @@
         - name: Verify Ubuntu OS Family architecture
           ansible.builtin.assert:
             that:
-              - ansible_distribution_major_version == '24'
-            fail_msg: "K3s Server OS major version must be 24"
+              - ansible_distribution_major_version in ['24', '26']
+            fail_msg: "K3s Server OS major version must be 24 or 26"
           when: ansible_os_family == "Debian"
 
         - name: Get mount location of /var directory

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -25,6 +25,12 @@ common_packages:
       - python3-setuptools
       - kubectl
       - python3-kubernetes
+    26:
+      - jq
+      - python3-pip
+      - python3-setuptools
+      - kubectl
+      - python3-kubernetes
 
 azure_gpg_keys:
   8:


### PR DESCRIPTION
Closes #197.

## Problem

Support for the Ubuntu/Debian family is pinned to major version 24 in two places:

- `playbooks/assertions.yml` asserts `ansible_distribution_major_version == '24'`, so a k3s install on the new LTS stops at the pre-flight check.
- `common_packages.Debian` in `playbooks/roles/common/vars/main.yml` only has keys `11` and `24`, so past that assertion `common_packages[ansible_os_family][ansible_distribution_major_version|int]` would raise an undefined key error on 26.

## Change

- The OS assertion now accepts `24` and `26`, with the failure message updated to match.
- `common_packages.Debian` gains a `26` entry with the same package list as `24` (`jq`, `python3-pip`, `python3-setuptools`, `kubectl`, `python3-kubernetes`).
- The requirement line in `README.md` and in the k3s and OCP install guides now reads "24 or 26".

The Kubernetes apt repository the installer configures is distribution independent (`https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /`), so it needs no change for the new release.

## Testing

Run in an `ubuntu:26.04` container (`Ubuntu 26.04 LTS`, `VERSION_ID="26.04"`, ansible-core 2.20), against real gathered facts.

`playbooks/assertions.yml` on `main`:

```
fatal: [localhost]: FAILED! => {
    "assertion": "ansible_distribution_major_version == '24'",
    "evaluated_to": false,
    "msg": "K3s Server OS major version must be 24"
}
```

On this branch the same play passes end to end (`ok=7 failed=0`), including the Ubuntu assertion.

Resolving the package list the `common` role installs, `common_packages[ansible_os_family][ansible_distribution_major_version|int]`:

| | result |
| --- | --- |
| `main` | `object of type 'dict' has no attribute 26` |
| this branch | `Ubuntu 26 -> ['jq', 'python3-pip', 'python3-setuptools', 'kubectl', 'python3-kubernetes']` |

`ansible-playbook --syntax-check playbooks/setup.yml` passes. A full k3s install on Ubuntu 26 was not attempted.

## Note

The issue also mentions dependency bumps. Nothing here bumps the pinned `v1.28` Kubernetes repository or the collection versions in `collections/requirements.yml`, since those affect every platform and deserve their own change; happy to follow up with a separate PR if you want them moved.
