### PR TITLE
feat: make the Kubernetes package repository optional

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -25,6 +25,10 @@ kube_install: false
     # Offline Install - Whether to use local assets to complete the install
 k8s_offline: false 
 
+    # Whether to configure the upstream Kubernetes package repository on the installing server
+    # Set this to false when kubectl is already served by a local mirror you have configured
+add_kubernetes_repo: true
+
     # Specify an INTERNAL container registry and namespace where the k8s cluster can access Ascender images
 k8s_container_registry: ""
 

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -27,6 +27,10 @@ k8s_offline: false
 # if you need the firewall to stay enabled
 firewalld_disable: true
 
+# Whether to configure the upstream Kubernetes package repository on the installing server.
+# Set this to false when kubectl is already served by a local mirror you have configured
+add_kubernetes_repo: true
+
 # Specify an INTERNAL container registry and namespace where the k8s cluster can access Ascender images
 k8s_container_registry: ""
 

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -41,7 +41,9 @@
           gpgcheck=1
           gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
       become: true
-      when: not k8s_offline
+      when:
+        - not k8s_offline
+        - add_kubernetes_repo
 
     - name: Install Necessary Packages (if offline)
       ansible.builtin.dnf:
@@ -69,23 +71,29 @@
         state: directory
         mode: '0755'
       become: true
+      when: add_kubernetes_repo
 
     - name: Check for repo key
       ansible.builtin.stat:
         path: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       register: k8s_keyring
+      when: add_kubernetes_repo
 
     - name: Get the K8s repo key
       ansible.builtin.shell: curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       become: true
-      when: not k8s_keyring.stat.exists
+      when:
+        - add_kubernetes_repo
+        - not k8s_keyring.stat.exists
 
     - name: Add the Kubernetes deb repository
       ansible.builtin.apt_repository:
         repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
         state: present
       become: true
-      when: not k8s_offline
+      when:
+        - not k8s_offline
+        - add_kubernetes_repo
 
     - name: Install Necessary Packages (if offline)
       ansible.builtin.apt:


### PR DESCRIPTION
Closes #153.

## Problem

The `common` role writes `/etc/yum.repos.d/kubernetes.repo` (and the equivalent apt source plus keyring) on every run. Sites that already serve the Kubernetes packages from a local mirror get the upstream repository put back each time the installer runs, and DNF then fails on hosts whose outbound access to `pkgs.k8s.io` is blocked. The only workaround today is commenting the task out locally.

## Change

New variable `add_kubernetes_repo`, default `true`, so nothing changes for existing users:

```yaml
    # Whether to configure the upstream Kubernetes package repository on the installing server
    # Set this to false when kubectl is already served by a local mirror you have configured
add_kubernetes_repo: true
```

When it is `false` the installer skips, on Enterprise Linux, the `kubernetes.repo` file, and on Ubuntu/Debian the keyring directory, the `Release.key` download and the apt source. The package install itself is untouched, so `kubectl` and the rest are taken from whatever repositories the host already has configured.

The variable is defined in `playbooks/group_vars/all.yml`, so configs written before this change keep working, and documented in `default.config.yml`, so it shows up in newly generated `custom.config.yml` files.

## Testing

Run in an `ubuntu:26.04` container, applying the `common` role with the option both ways and inspecting the host afterwards.

`add_kubernetes_repo: false`:

```
TASK [common : Ensure apt keyrings directory exists] ... skipping
TASK [common : Check for repo key]                  ... skipping
TASK [common : Get the K8s repo key]                ... skipping
TASK [common : Add the Kubernetes deb repository]   ... skipping
  -> /etc/apt/sources.list.d: ubuntu.sources
  -> /etc/apt/keyrings: (absent)
```

`add_kubernetes_repo: true`, the default:

```
TASK [common : Ensure apt keyrings directory exists] ... changed
TASK [common : Get the K8s repo key]                ... changed
TASK [common : Add the Kubernetes deb repository]   ... changed
  -> /etc/apt/sources.list.d: pkgs_k8s_io_core_stable_v1_28_deb.list ubuntu.sources
  -> /etc/apt/keyrings: kubernetes-apt-keyring.gpg
```

The package install step runs in both cases; with the repository disabled it takes `kubectl` from whatever repositories the host already has, which is the point of the option. `ansible-playbook --syntax-check playbooks/setup.yml` passes. The Enterprise Linux branch of the role uses the same guard but was not exercised in the container.
