### PR TITLE
feat: add the K3s firewalld rules when the firewall stays enabled

### DIFF
--- a/docs/installation/k3s/README.md
+++ b/docs/installation/k3s/README.md
@@ -35,6 +35,15 @@ If you have not done so already, be sure to follow the general prerequisites fou
   - If `kube_install` is set to true, the installer will set up K3s on the `ascender_host`in the
     inventory file. (`ascender_host` can be localhost)
   - If `kube_install` is set to false, the installer will not perform a K3s install
+- Firewall
+  - K3s recommends that `firewalld` is turned off, so the installer stops and disables it by
+    default on the k3s server
+  - To keep `firewalld` running, set `firewalld_disable: false`. The installer then applies the
+    rules K3s [requires](https://docs.k3s.io/installation/requirements): it opens `6443/tcp` for
+    the kube-api server, `80/tcp` and `443/tcp` for the ingress that serves Ascender, and adds the
+    pod network (`10.42.0.0/16`) and the service network (`10.43.0.0/16`) to the `trusted` zone
+  - Both lists can be changed with the `k3s_firewalld_ports` and `k3s_firewalld_trusted_sources`
+    variables
 - SSL Certificate and Key
   - To enable HTTPS on your website, you need to provide the Ascender installer with an SSL
     Certificate file, and a Private Key file. While these can be self-signed certificates, it is

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -27,6 +27,20 @@ k8s_offline: false
 # if you need the firewall to stay enabled
 firewalld_disable: true
 
+# The ports opened on the k3s node when firewalld is left enabled: the kube-api server,
+# plus http and https for the ingress that serves Ascender, Ledger and the Galaxy Proxy
+k3s_firewalld_ports:
+  - 6443/tcp
+  - 80/tcp
+  - 443/tcp
+
+# The k3s pod and service networks, added to the trusted zone when firewalld is left
+# enabled, so that pods and services can reach each other. See
+# https://docs.k3s.io/installation/requirements
+k3s_firewalld_trusted_sources:
+  - 10.42.0.0/16
+  - 10.43.0.0/16
+
 # Whether to configure the upstream Kubernetes package repository on the installing server.
 # Set this to false when kubectl is already served by a local mirror you have configured
 add_kubernetes_repo: true

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
@@ -14,6 +14,30 @@
     - firewalld_disable | bool 
     - "'firewalld.service' in services"
 
+- name: Configure firewalld for K3s
+  when:
+    - not firewalld_disable | bool
+    - "'firewalld.service' in services"
+    - services['firewalld.service'].state == 'running'
+  become: true
+  block:
+  - name: Open the ports required to reach the K3s cluster
+    ansible.posix.firewalld:
+      port: "{{ item }}"
+      permanent: true
+      immediate: true
+      state: enabled
+    loop: "{{ k3s_firewalld_ports }}"
+
+  - name: Trust the K3s pod and service networks
+    ansible.posix.firewalld:
+      source: "{{ item }}"
+      zone: trusted
+      permanent: true
+      immediate: true
+      state: enabled
+    loop: "{{ k3s_firewalld_trusted_sources }}"
+
 - name: Install K3s Online (this may take up to 5 minutes)
   ansible.builtin.shell: curl -sfL https://get.k3s.io | sh -
   when:


### PR DESCRIPTION
Closes #154.

## Problem

The installer stops and disables `firewalld` when `firewalld_disable` is true, but does nothing at all when it is false. Users who have to keep the firewall running are left with a k3s node where pods and services cannot reach each other, and the guides only mention opening http, https and ssh, which is not enough. The reporter found that the K3s [requirements](https://docs.k3s.io/installation/requirements) rules fixed it outright.

## Change

When `firewalld_disable: false` and firewalld is actually running on the k3s server, the installer now applies those rules with `ansible.posix.firewalld`, permanently and immediately:

- opens `6443/tcp` (kube-api server), `80/tcp` and `443/tcp` (the ingress serving Ascender, Ledger and the Galaxy Proxy)
- adds the pod network `10.42.0.0/16` and the service network `10.43.0.0/16` to the `trusted` zone

Both lists live in `playbooks/group_vars/all.yml` as `k3s_firewalld_ports` and `k3s_firewalld_trusted_sources`, so a site that uses different cluster CIDRs or does not want the ingress ports opened can override them.

The k3s install guide gains a Firewall section describing the default behaviour and what is applied when the firewall is kept.

Nothing changes for the default `firewalld_disable: true` path, and hosts without firewalld installed, or with it stopped, are skipped.

## Testing

Run in a Rocky Linux 9 container with `firewalld` and `python3-firewall` installed. The daemon cannot run in a container, so the tasks were executed with `immediate: false` to exercise the permanent configuration; everything else is as in this branch.

With `firewalld_disable: false` the two tasks apply cleanly and produce:

```xml
<!-- /etc/firewalld/zones/public.xml -->
<port port="6443" protocol="tcp"/>
<port port="80" protocol="tcp"/>
<port port="443" protocol="tcp"/>

<!-- /etc/firewalld/zones/trusted.xml -->
<source address="10.42.0.0/16"/>
<source address="10.43.0.0/16"/>
```

which is what `firewall-cmd --add-port=6443/tcp` and `--zone=trusted --add-source=...` produce in the K3s requirements. A second run reports `changed=0`, so the tasks are idempotent, and with the default `firewalld_disable: true` both tasks are skipped.

`ansible-playbook --syntax-check playbooks/setup.yml` passes. Not run against a Rocky 9 host with the firewalld daemon actually running, so the `immediate: true` path and the resulting cluster behaviour are untested.
