### PR TITLE
fix: fetch the k3s kubeconfig when the installer creates the cluster

### DIFF
--- a/default.config.yml
+++ b/default.config.yml
@@ -37,6 +37,7 @@ k8s_image_pull_secret: None
 k8s_ee_pull_credentials_secret: None
 
     # Indictates whether or not the kubeconfig file needs to be downloaded to the Ansible controller
+    # This is implied when kube_install is true, as that run creates the cluster and its kubeconfig
 download_kubeconfig: false
 
     # ---k3s variables---

--- a/docs/issues/kubeconfig_missing.md
+++ b/docs/issues/kubeconfig_missing.md
@@ -48,6 +48,7 @@ This will skip the step that tries to retrieve the kubeconfig from the target sy
 
 * This issue is common when running setup.sh against a brand-new host without any Kubernetes installation.
 * Ensure that either kube_install is enabled or a valid kubeconfig exists before setting download_kubeconfig: true.
+* When `kube_install` is `true`, the kubeconfig is retrieved from the new cluster whatever `download_kubeconfig` is set to, because that run is what creates the file.
 * The installer attempts to copy the config from /etc/rancher/k3s/k3s.yaml. If your config exists elsewhere, you may have to manually copy it over.
 * The installer will copy the config to ~/.kube/config
 

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -39,6 +39,7 @@ k8s_image_pull_secret: None
 k8s_ee_pull_credentials_secret: None
 
 # Indictates whether or not the kubeconfig file needs to be downloaded to the Ansible controller
+# This is implied when kube_install is true, as that run creates the cluster and its kubeconfig
 download_kubeconfig: false
 
 # ---k3s variables---

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
@@ -60,13 +60,16 @@
     state: directory
   delegate_to: localhost
 
+# A cluster built by this run writes its kubeconfig to /etc/rancher/k3s/k3s.yaml on the
+# server, so it is always fetched when kube_install is true; download_kubeconfig then only
+# covers pulling the file from a cluster that already existed.
 - name: Copy kubeconfig file from default location to the ~/.kube directory"
   ansible.builtin.fetch:
     src: /etc/rancher/k3s/k3s.yaml
     dest: ~/.kube/config
     flat: true
   become: true
-  when: download_kubeconfig
+  when: download_kubeconfig or kube_install
 
 - name: "Replace the kubeconfig cluster kube-api server IP with the public IP address, if the cluster is remote "
   ansible.builtin.replace:
@@ -76,7 +79,7 @@
   delegate_to: localhost
   when: 
     - ansible_host != "localhost"
-    - download_kubeconfig
+    - download_kubeconfig or kube_install
   
 - name: Get a list of all nodes
   kubernetes.core.k8s_info:


### PR DESCRIPTION
Closes #68.

## Problem

Installing a fresh single-node k3s cluster with the default `download_kubeconfig: false` fails right after the cluster comes up:

```
TASK [k8s_setup : Get a list of all nodes]
fatal: [ascender_host -> localhost]: FAILED! => {"changed": false,
  "msg": "Could not create API client: Invalid kube-config file. No configuration found."}
```

k3s writes its kubeconfig to `/etc/rancher/k3s/k3s.yaml` on the server, and the task that copies it to `~/.kube/config` on the controller is gated on `download_kubeconfig` alone. On a brand new cluster there is nothing else that could have placed that file, so every following task that talks to the cluster fails. Setting `download_kubeconfig: true` is the current workaround.

## Change

This is the fix suggested by @michaelford85 in the issue thread: the kubeconfig is fetched when `download_kubeconfig or kube_install` is true, and the same condition is applied to the follow-up task that rewrites the kube-api server address for a remote cluster.

`download_kubeconfig` keeps its meaning for the case it was added for, namely pulling the kubeconfig off a cluster that already exists, for instance when upgrading Ascender or Ledger.

Comments in `default.config.yml` and `playbooks/group_vars/all.yml`, plus the kubeconfig troubleshooting guide, now say that `kube_install: true` implies the download.

## Testing

Run in a container with a kubeconfig staged at `/etc/rancher/k3s/k3s.yaml`, executing the kubeconfig tasks from `k8s_setup_k3s.yml` on both versions.

`kube_install: true`, `download_kubeconfig: false`, local host:

| | `Copy kubeconfig file...` | result |
| --- | --- | --- |
| `main` | skipping | no `~/.kube/config`, which is where the reported failure comes from |
| this branch | changed | `~/.kube/config` present |

`kube_install: true`, `download_kubeconfig: false`, remote host (`ansible_host` not localhost): the fetch runs and the follow-up task rewrites the kube-api address to `k3s_master_node_ip`, which was also skipped before.

`kube_install: false`, `download_kubeconfig: false`: both tasks skip on both versions, so an existing cluster behaves exactly as it does today.

`ansible-playbook --syntax-check playbooks/setup.yml` passes. A full k3s install was not attempted.
