### PR TITLE
fix: wait for projects to be ready before creating job templates

### DIFF
--- a/playbooks/roles/setup_playbooks/tasks/projects.yml
+++ b/playbooks/roles/setup_playbooks/tasks/projects.yml
@@ -15,4 +15,41 @@
   retries: 20
   delay: 5
 
+# A job template is rejected with "Playbook not found for project" until the project's
+# SCM update has finished and the playbooks it published are readable through the API.
+# The project module only waits for the update when the response it gets back already
+# carries it, so wait for both conditions here rather than letting the template task
+# retry against a project that is not ready.
+- name: Wait for the SCM update of {{ project.name }} to finish
+  ansible.builtin.uri:
+    url: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}/api/v2/projects/{{ result.id }}/"
+    user: "{{ ASCENDER_ADMIN_USER }}"
+    password: "{{ ASCENDER_ADMIN_PASSWORD }}"
+    force_basic_auth: true
+    validate_certs: false
+  register: project_update
+  until: project_update.json.status | default('') in ['successful', 'failed', 'error', 'canceled']
+  retries: 60
+  delay: 10
+  ignore_errors: true
 
+- name: Wait for the playbooks of {{ project.name }} to be published
+  ansible.builtin.uri:
+    url: "{{ k8s_lb_protocol }}://{{ ascender_ip }}:{{ ascender_port }}/api/v2/projects/{{ result.id }}/playbooks/"
+    user: "{{ ASCENDER_ADMIN_USER }}"
+    password: "{{ ASCENDER_ADMIN_PASSWORD }}"
+    force_basic_auth: true
+    validate_certs: false
+  register: project_playbooks
+  until: project_playbooks.json | default([]) | length > 0
+  retries: 12
+  delay: 5
+  ignore_errors: true
+  when: project_update.json.status | default('') == 'successful'
+
+- name: Verify that {{ project.name }} is ready for its job templates
+  ansible.builtin.assert:
+    that:
+      - project_update.json.status | default('unknown') == 'successful'
+      - project_playbooks.json | default([]) | length > 0
+    fail_msg: "The project {{ project.name }} is not ready: its SCM update ended as '{{ project_update.json.status | default('unknown') }}' and it published {{ project_playbooks.json | default([]) | length }} playbooks. Job templates that use this project cannot be created until the update succeeds and its playbooks are visible through the API."


### PR DESCRIPTION
Closes #212.

## Problem

`ascender_setup_playbooks` fails while creating the demo job templates:

```
TASK [setup_playbooks : Create Job Template - Configure SELinux]
FAILED - RETRYING: [localhost]: Create Job Template - Configure SELinux (20 retries left).
...
fatal: [localhost]: FAILED! => {"attempts": 20, "changed": false,
  "msg": "Unable to create job_template Configure SELinux: {'playbook': ['Playbook not found for project.']}"}
```

Ascender rejects a job template until the project's SCM update has finished *and* the playbooks it published are readable through the API. The role goes straight from creating the projects to creating the templates, so whenever a project is not ready the failure surfaces 100 seconds later on the template, pointing at the wrong object: the template is fine, the project is not.

`awx.awx.project` does wait for the initial update, but only when the response it gets back already carries `summary_fields.current_update`, and it reports success on a later run even when the last update failed, so the role cannot rely on it to guarantee the state the next task needs.

## Change

After each project is created, `projects.yml` now waits for the state the template task actually depends on:

1. poll `/api/v2/projects/<id>/` until the SCM update reaches a final state (up to 10 minutes)
2. when it succeeded, poll `/api/v2/projects/<id>/playbooks/` until the list is populated (up to 1 minute)
3. assert both, failing on the project with a message naming its sync status and playbook count

Projects that are already synced pass all three on the first request, so re-runs are not slowed down.

## Testing

Run against a local Ascender dev instance (`tools/docker-compose`, Ascender API `0.1.dev11`, `awx.awx` 23.6.0), comparing `main` against this branch with the same project and job template definitions the role uses.

**A project that syncs but publishes no playbooks** (the state that produces the reported error):

| | result |
| --- | --- |
| `main` | fails after **2m31s** on `Create Job Template`: `{'playbook': ['Playbook not found for project.']}` |
| this branch | fails after **1m26s** on the project: `The project Empty Repo Test is not ready: its SCM update ended as 'successful' and it published 0 playbooks.` |

**A project whose SCM update fails** (unreachable repository):

| | result |
| --- | --- |
| `main` | project task passes, then fails after **2m38s** on `Create Job Template` with the same misleading `Playbook not found for project` |
| this branch | fails after **21s** on the project: `its SCM update ended as 'failed' and it published 0 playbooks` |

**Healthy project** (`ctrliq/ascender-playbooks`): both create the project and the job template successfully; the three added checks pass on their first attempt and cost about five seconds.

Note that on that dev instance the module's own wait did hold until the clone finished, so I could not reproduce the reporter's timing locally. What the change does guarantee is that the run stops on the object that is actually wrong, with the reason, instead of on the job template 100 seconds later, which should also tell the reporter whether their project sync failed or completed without publishing playbooks.
