### PR TITLE
fix: keep /etc/hosts in step with a changed hostname

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ These guides will walk you through the basics of setting up Ascender for the dif
 
 # Configuration Guides
 - [Setting up Automation Mesh](configuration/automation_mesh.md)
+- [Changing the Ascender or Ledger Hostname](configuration/changing_hostnames.md)
 - [Uninstalling Ascender or Ledger](configuration/uninstall.md)
 - [Upgrading Ascender or Ledger](configuration/upgrading.md)
 

--- a/docs/configuration/changing_hostnames.md
+++ b/docs/configuration/changing_hostnames.md
@@ -1,0 +1,84 @@
+# Changing the Ascender or Ledger Hostname
+
+## Overview
+
+The hostnames Ascender and Ledger are published under are set by `ASCENDER_HOSTNAME` and `LEDGER_HOSTNAME` in your
+configuration file. Both can be changed on a running deployment: update the configuration, re-run `setup.sh`, and the
+installer moves the deployment to the new names without a reinstall.
+
+## Prerequisites
+
+- A running Ascender deployment, installed with the same configuration file you are about to edit.
+- A DNS record for the new hostname, or `use_etc_hosts: true` if the installer should resolve it locally.
+- For `k8s_lb_protocol: https`, a certificate and key whose subject or SAN list covers the new hostname.
+
+> ⚠️ **Important:** Anything that already points at the old hostname keeps pointing at it. Update bookmarks, callback
+> URLs registered with an identity provider, execution node configurations, and any automation that calls the API.
+
+## Steps to Change a Hostname
+
+### 1. Update the Hostname in Your Configuration File
+
+Open your `custom.config.yml` file and set the new value:
+
+```yaml
+ASCENDER_HOSTNAME: ascender.mycompany.com
+```
+
+`LEDGER_HOSTNAME` works the same way, and the two must stay different from each other.
+
+### 2. Confirm the New Hostname Resolves
+
+If you run your own DNS, create the record for the new hostname before re-running the installer, as described in
+[Ascender Website Not Loading Due to DNS Resolution Failure](../issues/unresolvable_dns.md).
+
+If you rely on the installer instead, leave `use_etc_hosts: true` and it will maintain `/etc/hosts` on the machine you
+run `setup.sh` from:
+
+```yaml
+use_etc_hosts: true
+```
+
+### 3. Keep the Cluster Settings As They Are
+
+Your cluster already exists, so re-running the installer should not try to build it again:
+
+```yaml
+kube_install: false
+download_kubeconfig: false
+```
+
+### 4. Re-run the Installer
+
+```bash
+./setup.sh
+```
+
+The run applies the new hostname to the Ascender object, and the operator rewrites the ingress rule and restarts the
+web and task pods so that the new hostname is accepted as a trusted origin. The `/etc/hosts` entries the installer
+owns are written inside a block marked `ASCENDER INSTALLER MANAGED HOSTS`, which is rewritten on every run, so the
+entries of the previous hostname are removed as part of the same step.
+
+### 5. Verify the New Hostname
+
+Check that the ingress rule carries the new hostname:
+
+```bash
+kubectl get ingress -n ascender
+```
+
+Then confirm the API answers on it:
+
+```bash
+curl -sS http://ascender.mycompany.com/api/v2/ping/
+```
+
+## Notes
+
+- Installer versions before the managed block wrote one unmarked line per hostname into `/etc/hosts`. The first run
+  after upgrading adopts the current hostnames into the block, but a line left behind by an earlier hostname is not
+  recognized as installer owned, so remove it by hand if you no longer want the old name to resolve.
+- On OpenShift the hostname is published as a route, which has to resolve through the DNS server that serves the
+  cluster wildcard record, so `use_etc_hosts` does not apply there.
+- Ledger records the URL it uses to reach Ascender, and re-running the installer refreshes it, so change both
+  hostnames in the same run when you are moving the whole deployment to a new domain.

--- a/playbooks/roles/k8s_setup/tasks/etc_hosts.yml
+++ b/playbooks/roles/k8s_setup/tasks/etc_hosts.yml
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Ctrl IQ, Inc. All rights reserved.
+#
+# Maintains the /etc/hosts entries that the installer owns on the Ansible controller.
+#
+# Every hostname the install publishes is written inside a single marked block, so a run
+# that changes ASCENDER_HOSTNAME, LEDGER_HOSTNAME or PROXY_HOSTNAME replaces the entries
+# of the previous run instead of adding a second set next to them. Entries written by
+# earlier versions of the installer, which appended one unmarked line per hostname, are
+# removed for the hostnames managed here so that the block remains the only place these
+# names are resolved from.
+#
+# Callers have to set:
+#   etc_hosts_ip: the address these hostnames must resolve to
+# Callers may set:
+#   etc_hosts_unsafe_writes: true where /etc/hosts cannot be replaced atomically
+
+- name: Gather the hostnames this install publishes
+  ansible.builtin.set_fact:
+    etc_hosts_marker_comment: "# managed by ascender-install"
+    etc_hosts_names: >-
+      {{ [ASCENDER_HOSTNAME]
+         + ([LEDGER_HOSTNAME] if LEDGER_INSTALL | bool else [])
+         + ([PROXY_HOSTNAME] if PROXY_INSTALL | bool else []) }}
+
+- name: Remove unmarked /etc/hosts entries for the hostnames the installer manages
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    # Matches a host entry that lists this exact hostname, but never one of the marked
+    # lines the block below owns. The hostname is escaped because an unescaped name such
+    # as ascender1.local also matches ascender1.localdomain, which made the installer
+    # treat an unrelated entry as its own.
+    regexp: >-
+      ^(?!.*{{ etc_hosts_marker_comment | regex_escape }})\s*\S+\s+(\S+\s+)*{{ item | regex_escape }}(\s|$)
+    state: absent
+    owner: root
+    group: root
+    mode: '0644'
+    unsafe_writes: "{{ etc_hosts_unsafe_writes | default(false) }}"
+  become: true
+  delegate_to: localhost
+  loop: "{{ etc_hosts_names }}"
+
+- name: "Ensure local DNS entries for {{ etc_hosts_names | join(', ') }} exist"
+  ansible.builtin.blockinfile:
+    path: /etc/hosts
+    marker: "# {mark} ASCENDER INSTALLER MANAGED HOSTS"
+    block: |-
+      {% for name in etc_hosts_names %}
+      {{ etc_hosts_ip }}   {{ name }}   {{ etc_hosts_marker_comment }}
+      {% endfor %}
+    owner: root
+    group: root
+    mode: '0644'
+    unsafe_writes: "{{ etc_hosts_unsafe_writes | default(false) }}"
+  become: true
+  delegate_to: localhost

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_dkp.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_dkp.yml
@@ -49,54 +49,8 @@
   environment:
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/config_dkp"
 
-- name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ ASCENDER_HOSTNAME }}"
-    line: "{{ svc_output.resources[0].status.loadBalancer.ingress[0].ip }}   {{ ASCENDER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: use_etc_hosts
-
-- name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ LEDGER_HOSTNAME }}"
-    line: "{{ svc_output.resources[0].status.loadBalancer.ingress[0].ip }}   {{ LEDGER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: 
-    - use_etc_hosts
-    - LEDGER_INSTALL
-    
-# - name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} is removed is using external DNS"
-#   ansible.builtin.lineinfile:
-#     path: /etc/hosts
-#     regexp: "{{ LEDGER_HOSTNAME }}"
-#     state: absent
-#     owner: root
-#     group: root
-#     mode: '0644'
-#   become: true
-#   delegate_to: localhost
-#   when: 
-#     - not use_etc_hosts
-#     - LEDGER_INSTALL
-
-# - name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} is removed if using external DNS"
-#   ansible.builtin.lineinfile:
-#     path: /etc/hosts
-#     regexp: "{{ ASCENDER_HOSTNAME }}"
-#     state: absent
-#     owner: root
-#     group: root
-#     mode: '0644'
-#   become: true
-#   delegate_to: localhost
-#   when: not use_etc_hosts
+- name: Maintain the /etc/hosts entries for this install
+  ansible.builtin.include_tasks: etc_hosts.yml
+  vars:
+    etc_hosts_ip: "{{ svc_output.resources[0].status.loadBalancer.ingress[0].ip }}"
+  when: use_etc_hosts | bool

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_k3s.yml
@@ -87,54 +87,8 @@
   environment:
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/config"
 
-- name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ ASCENDER_HOSTNAME }}"
-    line: "{{ k3s_master_node_ip }}   {{ ASCENDER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: use_etc_hosts
-
-# - name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} is removed if using external DNS"
-#   ansible.builtin.lineinfile:
-#     path: /etc/hosts
-#     regexp: "{{ ASCENDER_HOSTNAME }}"
-#     state: absent
-#     owner: root
-#     group: root
-#     mode: '0644'
-#   become: true
-#   delegate_to: localhost
-#   when: not use_etc_hosts
-
-- name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ LEDGER_HOSTNAME }}"
-    line: "{{ k3s_master_node_ip }}   {{ LEDGER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when:
-    - use_etc_hosts
-    - LEDGER_INSTALL
-
-- name: "Ensure a local DNS entry for {{ PROXY_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ PROXY_HOSTNAME }}"
-    line: "{{ k3s_master_node_ip }}   {{ PROXY_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when:
-    - use_etc_hosts
-    - PROXY_INSTALL
+- name: Maintain the /etc/hosts entries for this install
+  ansible.builtin.include_tasks: etc_hosts.yml
+  vars:
+    etc_hosts_ip: "{{ k3s_master_node_ip }}"
+  when: use_etc_hosts | bool

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_rke2.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_rke2.yml
@@ -36,54 +36,8 @@
   environment:
     K8S_AUTH_KUBECONFIG: "{{ lookup('env', 'HOME') }}/.kube/config"
 
-- name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ ASCENDER_HOSTNAME }}"
-    line: "{{ kubeapi_server_ip }}   {{ ASCENDER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: use_etc_hosts
-
-# - name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} is removed if using external DNS"
-#   ansible.builtin.lineinfile:
-#     path: /etc/hosts
-#     regexp: "{{ ASCENDER_HOSTNAME }}"
-#     state: absent
-#     owner: root
-#     group: root
-#     mode: '0644'
-#   become: true
-#   delegate_to: localhost
-#   when: not use_etc_hosts
-
-- name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} exists"
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ LEDGER_HOSTNAME }}"
-    line: "{{ kubeapi_server_ip }}   {{ LEDGER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-  become: true
-  delegate_to: localhost
-  when: 
-    - use_etc_hosts
-    - LEDGER_INSTALL
-    
-# - name: "Ensure a local DNS entry for {{ LEDGER_HOSTNAME }} is removed is using external DNS"
-#   ansible.builtin.lineinfile:
-#     path: /etc/hosts
-#     regexp: "{{ LEDGER_HOSTNAME }}"
-#     state: absent
-#     owner: root
-#     group: root
-#     mode: '0644'
-#   become: true
-#   delegate_to: localhost
-#   when: 
-#     - not use_etc_hosts
-#     - LEDGER_INSTALL
+- name: Maintain the /etc/hosts entries for this install
+  ansible.builtin.include_tasks: etc_hosts.yml
+  vars:
+    etc_hosts_ip: "{{ kubeapi_server_ip }}"
+  when: use_etc_hosts | bool

--- a/playbooks/roles/k8s_setup/tasks/k8s_setup_tkgi.yml
+++ b/playbooks/roles/k8s_setup/tasks/k8s_setup_tkgi.yml
@@ -283,36 +283,13 @@
     - contour_envoy_service.stdout is defined
     - contour_envoy_service.stdout | length > 0
 
-- name: Ensure a local DNS entry for Ascender exists when an ingress IP is available
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ ASCENDER_HOSTNAME }}"
-    line: "{{ tkgi_ingress_address }}   {{ ASCENDER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-    unsafe_writes: true
-  become: true
-  delegate_to: localhost
+- name: Maintain the /etc/hosts entries for this install when an ingress IP is available
+  ansible.builtin.include_tasks: etc_hosts.yml
+  vars:
+    etc_hosts_ip: "{{ tkgi_ingress_address }}"
+    etc_hosts_unsafe_writes: true
   when:
     - use_etc_hosts | bool
-    - tkgi_ingress_address is defined
-    - tkgi_ingress_address | length > 0
-
-- name: Ensure a local DNS entry for Ledger exists when an ingress IP is available
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: "{{ LEDGER_HOSTNAME }}"
-    line: "{{ tkgi_ingress_address }}   {{ LEDGER_HOSTNAME }}"
-    owner: root
-    group: root
-    mode: '0644'
-    unsafe_writes: true
-  become: true
-  delegate_to: localhost
-  when:
-    - use_etc_hosts | bool
-    - LEDGER_INSTALL | bool
     - tkgi_ingress_address is defined
     - tkgi_ingress_address | length > 0
 


### PR DESCRIPTION
Closes #29.

## Problem

Changing `ASCENDER_HOSTNAME` and re-running `setup.sh` leaves the old name resolving and can fail to publish the new one. Each platform kept its own pair of `lineinfile` tasks that matched an existing entry with the hostname used directly as a regular expression:

```yaml
- name: "Ensure a local DNS entry for {{ ASCENDER_HOSTNAME }} exists"
  ansible.builtin.lineinfile:
    path: /etc/hosts
    regexp: "{{ ASCENDER_HOSTNAME }}"
    line: "{{ k3s_master_node_ip }}   {{ ASCENDER_HOSTNAME }}"
```

That has two consequences on a re-run:

- The pattern is neither escaped nor anchored, so it matches inside a longer name. On the reporter's `ascender1` host, `ascender1.local` matches an existing `ascender1.localdomain ascender1` entry, and the task rewrites that unrelated line instead of adding the entry Ascender needs.
- Nothing removes the entry the previous run wrote, so the old hostname keeps resolving to the cluster and `/etc/hosts` grows one stale line per rename.

## Change

The duplicated per-platform tasks are replaced with a shared `k8s_setup/tasks/etc_hosts.yml`, included by the k3s, RKE2, DKP and TKGI paths with the address that platform publishes on:

- Every hostname the install publishes (Ascender, plus Ledger and the Galaxy Proxy when they are installed) is written inside one `ASCENDER INSTALLER MANAGED HOSTS` block, which is rewritten on each run. A renamed host therefore replaces the previous entry rather than adding a second one, and so does a changed ingress address.
- Entries are matched by escaped, anchored hostname, so `ascender1.local` no longer matches `ascender1.localdomain`.
- Unmarked lines for a hostname that is now managed are removed first, so the entries written by earlier installer versions are adopted into the block instead of being duplicated.

Managed lines carry a `# managed by ascender-install` comment, which is what keeps the cleanup step from touching the block itself and makes the entries recognizable in the file.

A configuration guide covers what to change and what the re-run does, which is the part the reporter said was unclear.

OCP is left alone here, since #216 removes its `/etc/hosts` tasks altogether.

## Testing

The task file was run against a copy of a stock `/etc/hosts` seeded with a legacy `ascender.example.com` entry and an unrelated `192.168.1.10 ascender1.localdomain ascender1` line:

- renaming to `ascender1.local` adds the block, adopts the legacy Ledger entry into it, and leaves the `ascender1.localdomain` line untouched, which the old task rewrote
- re-running with the same values reports no change
- renaming again, with a different ingress address, replaces both entries in place

Not run against a live cluster.
