### PR TITLE
fix(ascender-migrate): Gather AWX hostname via AWX CRD instead of OCP Route

### DIFF
--- a/playbooks/roles/awx_migrate_ascender/tasks/configure.yml
+++ b/playbooks/roles/awx_migrate_ascender/tasks/configure.yml
@@ -9,9 +9,6 @@
     api_version: awx.ansible.com/v1beta1
     name: "{{ ascender.instance }}"
     namespace: "{{ ascender.namespace }}"
-    label_selectors:
-      - "app.kubernetes.io/managed-by=awx-operator"
-      - "app.kubernetes.io/part-of={{ ascender.instance }}"
   register: ascender_hostname
 
 - name: Get Ascender web pod

--- a/playbooks/roles/awx_migrate_ascender/tasks/configure.yml
+++ b/playbooks/roles/awx_migrate_ascender/tasks/configure.yml
@@ -3,14 +3,16 @@
 # Runs AFTER startup (API must be live) and BEFORE verify.
 # Ported from roles/awx_restore/tasks/restore_configure_web.yml.
 
-- name: Get Ascender route
+- name: Get Ascender hostname
   kubernetes.core.k8s_info:
-    kind: Route
+    kind: AWX
+    api_version: awx.ansible.com/v1beta1
+    name: "{{ ascender.instance }}"
     namespace: "{{ ascender.namespace }}"
     label_selectors:
       - "app.kubernetes.io/managed-by=awx-operator"
       - "app.kubernetes.io/part-of={{ ascender.instance }}"
-  register: ascender_route
+  register: ascender_hostname
 
 - name: Get Ascender web pod
   kubernetes.core.k8s_info:
@@ -42,7 +44,7 @@
 - name: Define controller auth parameters
   ansible.builtin.set_fact:
     awx_controller_auth:
-      host: "https://{{ ascender_route.resources[0].spec.host }}"
+      host: "https://{{ ascender_hostname.resources[0].spec.hostname }}"
       username: admin
       password: "{{ admin_password }}"
       verify_ssl: false

--- a/playbooks/roles/awx_migrate_ascender/tasks/verify.yml
+++ b/playbooks/roles/awx_migrate_ascender/tasks/verify.yml
@@ -1,20 +1,31 @@
 ---
-- name: Get Ascender route
+- name: Get Ascender hostname
   kubernetes.core.k8s_info:
-    kind: Route
+    api_version: awx.ansible.com/v1beta1
+    kind: AWX
+    name: "{{ ascender.instance }}"
     namespace: "{{ ascender.namespace }}"
     label_selectors:
       - "app.kubernetes.io/managed-by=awx-operator"
       - "app.kubernetes.io/part-of={{ ascender.instance }}"
-  register: ascender_route
+  register: ascender_hostname
+
+- name: Validate Ascender hostname
+  ansible.builtin.assert:
+    that:
+      - ascender_hostname.resources | length == 1
+      - ascender_hostname.resources[0].spec.hostname is defined
+      - ascender_hostname.resources[0].spec.hostname | length > 0
+    fail_msg: >-
+      Ascender AWX CR {{ ascender.namespace }}/{{ ascender.instance }}
+      does not contain spec.hostname
 
 - name: Verify Ascender API is accessible
   ansible.builtin.uri:
-    url: "https://{{ ascender_route.resources[0].spec.host }}/api/v2/"
+    url: "https://{{ ascender_hostname.resources[0].spec.hostname }}/api/v2/"
     validate_certs: false
   register: api_check
   until: api_check.status == 200
   delay: 5
   retries: 5
-  when: ascender_route.resources | length > 0
-
+  when: ascender_hostname.resources | length > 0

--- a/playbooks/roles/awx_migrate_ascender/tasks/verify.yml
+++ b/playbooks/roles/awx_migrate_ascender/tasks/verify.yml
@@ -5,9 +5,6 @@
     kind: AWX
     name: "{{ ascender.instance }}"
     namespace: "{{ ascender.namespace }}"
-    label_selectors:
-      - "app.kubernetes.io/managed-by=awx-operator"
-      - "app.kubernetes.io/part-of={{ ascender.instance }}"
   register: ascender_hostname
 
 - name: Validate Ascender hostname


### PR DESCRIPTION
While migrating from AWX to Ascender with AWX installed on a Kubernetes cluster the `awx_migrate_ascender` Ansible Role it does fail because on `Route` resource does normally don't exist in Kubernetes, it's present only in OCP/OKD.

This PR modify the `awx_migrate_ascender` to read the hostname/fqdn from the CRD `AWX` since this resource it does exist on both Kubernetes and OCP/OKD