### PR TITLE
fix: don't require the Default org to be ID 1 in the installer readiness gate

### DIFF
--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_aks.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_aks.yml
@@ -20,7 +20,7 @@
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
     name: Default
     state: exists
-  until:  org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_dkp.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_dkp.yml
@@ -21,7 +21,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until: org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_eks.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_eks.yml
@@ -21,9 +21,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until:
-    - org.id is defined
-    - org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_gke.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_gke.yml
@@ -20,7 +20,7 @@
     controller_password: "{{ ASCENDER_ADMIN_PASSWORD }}"
     name: Default
     state: exists
-  until:  org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_k3s.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_k3s.yml
@@ -14,7 +14,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until: org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_ocp.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_ocp.yml
@@ -15,7 +15,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until: org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_rke2.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_rke2.yml
@@ -21,7 +21,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until: org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org

--- a/playbooks/roles/setup_playbooks/tasks/ascender_credentials_tkgi.yml
+++ b/playbooks/roles/setup_playbooks/tasks/ascender_credentials_tkgi.yml
@@ -21,7 +21,7 @@
     name: Default
     state: exists
     validate_certs: false
-  until: org.id is defined and org.id == 1
+  until: org.id is defined
   retries: 200
   delay: 10
   register: org


### PR DESCRIPTION
The readiness gate waits for the `Default` org to have primary key `1`, which may not be the case after the server has been around for a time. Anywhere the org was created later, the condition never becomes true and the task retries for 33 minutes and fails. 